### PR TITLE
fix(electron): 正しくレンダラーをロードして本番環境での白画面を修正

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,5 @@
-import { app, BrowserWindow, protocol } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import { join } from 'node:path'
-import { normalize } from 'node:path'
 
 const isDev = !!process.env.VITE_DEV_SERVER_URL
 
@@ -23,35 +22,11 @@ async function createWindow() {
     await win.loadURL(process.env.VITE_DEV_SERVER_URL)
     win.webContents.openDevTools({ mode: 'detach' })
   } else {
-    await win.loadURL('app://index.html')
+    await win.loadFile(join(__dirname, '../dist/renderer/index.html'))
   }
 }
 
-// Register a secure custom protocol to serve built files in production
-protocol.registerSchemesAsPrivileged([
-  { scheme: 'app', privileges: { standard: true, secure: true, supportFetchAPI: true } },
-])
-
 app.whenReady().then(() => {
-  if (!isDev) {
-    const baseDir = join(process.resourcesPath, 'dist/renderer')
-    protocol.registerFileProtocol('app', (request, callback) => {
-      try {
-        const url = new URL(request.url)
-        let pathname = url.pathname
-        if (!pathname || pathname === '/') pathname = '/index.html'
-        // Prevent path traversal and map to resources/dist/renderer
-        const resolved = normalize(join(baseDir, decodeURIComponent(pathname).replace(/^\//, '')))
-        if (!resolved.startsWith(normalize(baseDir))) {
-          return callback({ error: -6 }) // net::ERR_FILE_NOT_FOUND
-        }
-        return callback(resolved)
-      } catch {
-        return callback({ error: -324 }) // net::ERR_INVALID_URL
-      }
-    })
-  }
-
   createWindow()
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()


### PR DESCRIPTION
プロダクションモードでアプリを実行した際に発生する白画面の問題を修正しました。

原因は、レンダラーの `index.html` を読み込むために使用されていたカスタムの `app://` プロトコルが、特にパッケージ化されたアプリケーション（asarアーカイブ内）で正しく機能していなかったことでした。この実装は、パッケージ化によって無効になる直接的なファイルシステムパスに依存していました。

この問題を解決するため、複雑で不具合のあったカスタムプロトコルの実装を、Electronの標準的で堅牢な `win.loadFile()` メソッドに置き換えました。これにより、ビルドされた `index.html` へのパスが正しく解決され、レンダラーが確実に読み込まれるようになります。